### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ using a go no-go paradigm), as well as general information (age, gender, educati
 handedness and weight). 
   - The EEG data contains recordings with at least 30 minutes duration including the following 
   conditions: eyes closed, eyes open, hyperventilation and subsequent recovery. 
-  - The MRI consisted in anatomical T1 and T2 as well as diffusion weighted (DWI)
+  - The MRI consisted in anatomical T1 as well as diffusion weighted (DWI)
 images acquired on a 1.5 Tesla system. 
 
 The data is available for registered users on the LORIS


### PR DESCRIPTION
The Cuban Human Brain Mapping Normative database
The Cuban Human Brain Mapping Project (CHBMP) repository is an open multimodal neuroimaging and cognitive dataset from 282 healthy participants (31.9 ± 9.3 years, age range 18–68 years).

This dataset was acquired from 2004 to 2008 as a subset of a larger stratified random sample of 2,019 participants from La Lisa municipality in La Habana, Cuba. The exclusion included presence of disease or brain dysfunctions.

The information made available for all participants comprises: high-density (64-120 channels) resting state electroencephalograms (EEG), magnetic resonance images (MRI), psychological tests (MMSE, Wechsler Adult Intelligence Scale -WAIS III, computerized reaction time tests using a go no-go paradigm), as well as general information (age, gender, education, ethnicity, handedness and weight).

The EEG data contains recordings with at least 30 minutes duration including the following conditions: eyes closed, eyes open, hyperventilation and subsequent recovery.
The MRI consisted in anatomical T1 as well as diffusion weighted (DWI) images acquired on a 1.5 Tesla system.
The data is available for registered users on the LORIS database which is part of the MNI neuroinformatics ecosystem (https://cuba-open.loris.ca).