### PR TITLE
Fix date type in DATS file

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -213,7 +213,7 @@
           "date": "2011-07-01",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -304,7 +304,7 @@
           "date": "2009-12-15",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -500,7 +500,7 @@
           "date": "2020",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -574,7 +574,7 @@
           "date": "2019-11-05",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -674,7 +674,7 @@
           "date": "2010-01-18",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -765,7 +765,7 @@
           "date": "2009-10-19",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -857,7 +857,7 @@
           "date": "2007-02-15",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -928,7 +928,7 @@
           "date": "2007-11-19",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],
@@ -1001,7 +1001,7 @@
           "date": "2015-08-20",
           "type": 
             {
-              "value": "Publication Date"
+              "value": "publication date"
             }
         }
       ],


### PR DESCRIPTION
The date type was encoded 'Publication Date' in the DATS file. This corrects it to 'publication date' which corresponds to the convention of having date types all lower case.